### PR TITLE
第3回ハブに授業スライドへの動線を追加

### DIFF
--- a/lessons/lesson-03/index.html
+++ b/lessons/lesson-03/index.html
@@ -90,6 +90,12 @@
         <span>DevTools Console</span>
       </div>
 
+      <h2>授業スライド（講師用）</h2>
+      <p>
+        <a href="./slides/index.html">第3回 スライド（Reveal.js / ブラウザ全画面）</a>
+        — 授業進行用。矢印キー／スペースで進む、<code>S</code> キーでスピーカーノート表示。
+      </p>
+
       <h2>練習問題</h2>
       <ol class="practices">
         <li>


### PR DESCRIPTION
## 概要

第3回レッスンハブ `lessons/lesson-03/index.html` に **授業スライドへの動線が抜けていた**ため追加します。

## 確認した状況

- **第2回**: `lessons/lesson-02/index.html` に「授業スライド（講師用）」セクションがあり、練習問題リストの直前に `./slides/` へのリンクを配置（PR #11 で追加）。
- **第3回**: `slides/index.html` 自体は存在・公開済（200）だが、ハブからの動線が無かった。
- ルート講座トップ `index.html` は第2回ブロックにもスライド動線を持たないため、ルート側は変更なし（第2回とパリティ）。

## 変更点

- `lessons/lesson-03/index.html` の練習問題セクション直前に「授業スライド（講師用）」セクションを追加（第2回と同一書式・文言・位置）。リンク先は `./slides/index.html`（GitHub Pages で相対解決される）。
- 編集元 `src/lesson-03/index.html` も同内容で同期済み（src と github 公開本体を一致させた）。

既存の lesson-03 公開物・リンクは変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)